### PR TITLE
Fix sticky header

### DIFF
--- a/src/App/App.scss
+++ b/src/App/App.scss
@@ -2,5 +2,7 @@
 
 #root {
   width: 100vw;
+  height: 100vh;
   overflow-x: hidden;
+  overflow-y: auto;
 }


### PR DESCRIPTION
It turns out that if `position: sticky` is used with overflow: hidden, you need to specify a height for the parent container.  